### PR TITLE
Integrate statsd metric target with dogstatsd client

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,7 @@ module github.com/Jeffail/benthos/v3
 require (
 	cloud.google.com/go/pubsub v1.0.1
 	github.com/Azure/go-ansiterm v0.0.0-20170929234023-d6e3b3328b78 // indirect
+	github.com/DataDog/datadog-go v3.2.0+incompatible
 	github.com/DataDog/zstd v1.4.1 // indirect
 	github.com/Jeffail/gabs/v2 v2.1.0
 	github.com/Microsoft/go-winio v0.4.14 // indirect
@@ -64,7 +65,7 @@ require (
 	github.com/prometheus/client_model v0.0.0-20190812154241-14fe0d1b01d4 // indirect
 	github.com/prometheus/procfs v0.0.4 // indirect
 	github.com/quipo/dependencysolver v0.0.0-20170801134659-2b009cb4ddcc
-	github.com/quipo/statsd v0.0.0-20180118161217-3d6a5565f314
+	github.com/quipo/statsd v0.0.0-20180118161217-3d6a5565f314 // indirect
 	github.com/rcrowley/go-metrics v0.0.0-20190826022208-cac0b30c2563 // indirect
 	github.com/sirupsen/logrus v1.4.2 // indirect
 	github.com/smartystreets/assertions v0.0.0-20190215210624-980c5ac6f3ac // indirect

--- a/lib/metrics/statsd.go
+++ b/lib/metrics/statsd.go
@@ -241,19 +241,15 @@ func (h *Statsd) Close() error {
 }
 
 // tags merges tag labels with their interpolated values
-// assumes that the input lists are the same length and
-// that labels[i] maps to values[i] for all i.
 //
-// Behavior for labels and values containing
-// the `:` character is undefined.
+// no attempt is made to merge labels and values if slices
+// are not the same length
 func tags(labels []string, values []string) []string {
+	if len(labels) != len(values) {
+		return nil
+	}
 	tags := make([]string, len(labels))
 	for i := range labels {
-		// We said we assumed the len(labels) == len(values),
-		// but we may as well check to be safe
-		if i >= len(values) {
-			break
-		}
 		tags[i] = fmt.Sprintf("%s:%s", labels[i], values[i])
 	}
 	return tags

--- a/lib/metrics/statsd_test.go
+++ b/lib/metrics/statsd_test.go
@@ -1,0 +1,41 @@
+// Copyright (c) 2019 Daniel Rubenstein
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, sub to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package metrics
+
+import (
+	"testing"
+)
+
+func TestStatsDTags(t *testing.T) {
+	tagslice := tags([]string{"tag1", "tag2"}, []string{"value1", "value2"})
+	if "tag1:value1" != tagslice[0] {
+		t.Errorf("%s != %s", "tag1:value1", tagslice[0])
+	}
+	if "tag2:value2" != tagslice[1] {
+		t.Errorf("%s != %s", "tag2:value2", tagslice[1])
+	}
+
+	tagslice = tags([]string{"tag1", "tag2"}, []string{"value1"})
+	if "tag1:value1" != tagslice[0] {
+		t.Errorf("%s != %s", "tag1:value1", tagslice[0])
+	}
+
+}

--- a/lib/metrics/statsd_test.go
+++ b/lib/metrics/statsd_test.go
@@ -1,23 +1,3 @@
-// Copyright (c) 2019 Daniel Rubenstein
-//
-// Permission is hereby granted, free of charge, to any person obtaining a copy
-// of this software and associated documentation files (the "Software"), to deal
-// in the Software without restriction, including without limitation the rights
-// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-// copies of the Software, and to permit persons to whom the Software is
-// furnished to do so, sub to the following conditions:
-//
-// The above copyright notice and this permission notice shall be included in
-// all copies or substantial portions of the Software.
-//
-// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
-// THE SOFTWARE.
-
 package metrics
 
 import (

--- a/lib/metrics/statsd_test.go
+++ b/lib/metrics/statsd_test.go
@@ -14,8 +14,7 @@ func TestStatsDTags(t *testing.T) {
 	}
 
 	tagslice = tags([]string{"tag1", "tag2"}, []string{"value1"})
-	if "tag1:value1" != tagslice[0] {
-		t.Errorf("%s != %s", "tag1:value1", tagslice[0])
+	if len(tagslice) != 0 {
+		t.Errorf("expected tagslice to be empty: %v", tagslice)
 	}
-
 }


### PR DESCRIPTION
This change migrates the metrics target from the `quipo/statsd` client to the `datadog/datadog-go/statsd` client. The major benefit of this is that the labels you have on your metrics processors will now be ingested as tags. For example if you have the label: 

```
metric:
  labels:
    key: ${!json_field:value}
```
for the following message: 

```
{
  "value": 100
}
``` 
then the statsd metric will output the following tag: `key:100`. 

It's worth noting that this may be a breaking change for folks using the metric target type, particularly if you have your metric target network set to `TCP`.