### PR TITLE
Add support for interpolated strings in HTTP client input type

### DIFF
--- a/lib/input/http_client.go
+++ b/lib/input/http_client.go
@@ -33,6 +33,7 @@ import (
 	"github.com/Jeffail/benthos/v3/lib/metrics"
 	"github.com/Jeffail/benthos/v3/lib/types"
 	"github.com/Jeffail/benthos/v3/lib/util/http/client"
+	"github.com/Jeffail/benthos/v3/lib/util/text"
 )
 
 //------------------------------------------------------------------------------
@@ -117,8 +118,10 @@ func NewHTTPClient(conf Config, mgr types.Manager, log log.Modular, stats metric
 		// Timeout should be left at zero if we are streaming.
 		h.conf.HTTPClient.Timeout = ""
 	}
-	if len(h.conf.HTTPClient.Payload) > 0 {
-		h.payload = message.New([][]byte{[]byte(h.conf.HTTPClient.Payload)})
+
+	if h.conf.HTTPClient.Payload != "" {
+		interpolated := text.NewInterpolatedString(h.conf.HTTPClient.Payload).Get(nil)
+		h.payload = message.New([][]byte{[]byte(interpolated)})
 	}
 
 	var err error


### PR DESCRIPTION
You can now rely on string interpolation to dynamically generate http payloads for the http_client input type. This is especially useful if your payloads contain application secrets.
```
http_client:
    backoff_on:
    - 429
    copy_response_headers: true
    drop_on: []
    headers:
      Content-Type: application/json
    max_retry_backoff: 300s
    payload: |
      ${INPUT_PAYLOAD}
    rate_limit:
    retries: 3
    retry_period: 1s
    timeout: 1s
    url: ""
    verb: POST
```